### PR TITLE
Add ArtDeck to reference art boards

### DIFF
--- a/src/content/theory/art-software.md
+++ b/src/content/theory/art-software.md
@@ -111,7 +111,7 @@ This is a somewhat complete collection of all the software commonly used by prof
 
 - [**`PureRef`**](https://www.pureref.com)
 - [**`VizRef`**](https://vizref.com/) (For iOS devices)
-- [**`ArtDeck`**](https://getartdeck.com/) _(For iPhone, iPad, and Mac, with optional iCloud sync)_
+- [**`ArtDeck`**](https://getartdeck.com/) _(For iPhone, iPad, and Mac; optional iCloud sync; image and video study tools)_
 - [**`Milanote`**](https://milanote.com/) _(Feature rich and running in the cloud, making it quite portable)_
 - [**Opti**](https://github.com/torcado194/opti)
 - [**Kuadro**](http://www.kruelgames.com/tools/kuadro/)

--- a/src/content/theory/art-software.md
+++ b/src/content/theory/art-software.md
@@ -111,6 +111,7 @@ This is a somewhat complete collection of all the software commonly used by prof
 
 - [**`PureRef`**](https://www.pureref.com)
 - [**`VizRef`**](https://vizref.com/) (For iOS devices)
+- [**`ArtDeck`**](https://getartdeck.com/) _(For iPhone, iPad, and Mac, with optional iCloud sync)_
 - [**`Milanote`**](https://milanote.com/) _(Feature rich and running in the cloud, making it quite portable)_
 - [**Opti**](https://github.com/torcado194/opti)
 - [**Kuadro**](http://www.kruelgames.com/tools/kuadro/)


### PR DESCRIPTION
## What changed

- Added ArtDeck to the handbook's Reference Art Boards list.
- Linked to the ArtDeck product page and noted its availability on iPhone, iPad, and Mac, optional iCloud sync, and image and video study tools.

## Why

ArtDeck is a visual reference board with image and video study tools for the Apple ecosystem, so it fits alongside PureRef, VizRef, and the other reference-board tools already listed.

## Validation

- `git diff --check`
- Local site preview not run, as requested; this is a one-line Markdown addition.
